### PR TITLE
chore(renovate): group node updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -219,6 +219,8 @@
       // Exclude my own packages (handled separately)
       matchPackageNames: [
         '!/^@stanlemon\\//',
+        '!/^@types\\/node$/',
+        '!/^node$/',
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- keep node runtime, types, and engines in the same Renovate PR by excluding them from the generic npm group

## Testing
- `npm test` *(passed)*
- `npm run renovate:validate` *(failed: 403 Forbidden - GET https://registry.npmjs.org/renovate)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb1f2bfd0832dbf2bddac8e4cb21c